### PR TITLE
travis: use tox from Travis CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,6 +7,6 @@ python:
 
 cache: pip
 
-install: "pip install --upgrade -r test-requirements.txt"
+install: pip install tox-travis
 
-script: pytest
+script: tox

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = lint,py35,py36
+envlist = lint,py34,py35,py36
 
 [testenv]
 deps = -rtest-requirements.txt


### PR DESCRIPTION
We can now run `tox` from Travis CI and keep the test commands in just one place.